### PR TITLE
fix to use shotgun instead of rackup with the correct params passing

### DIFF
--- a/lib/guard/shotgun.rb
+++ b/lib/guard/shotgun.rb
@@ -30,7 +30,7 @@ module Guard
         UI.error "Another instance of Sinatra is running."
         false
       else
-        @pid = Spoon.spawnp('shotgun', '--port', @options[:port].to_s, '--server', @options[:server])
+        @pid = Spoon.spawnp('rackup', '--port', @options[:port].to_s, '--server', @options[:server])
         @pid
       end
       wait_for_port


### PR DESCRIPTION
fix to use shotgun instead of rackup with the correct params passing
