### PR TITLE
Fixed that Spoon.spawnp fails when Guard::Shotgun#config_file is nil

### DIFF
--- a/lib/guard/shotgun.rb
+++ b/lib/guard/shotgun.rb
@@ -34,7 +34,7 @@ module Guard
         UI.error "Another instance of Rack is running."
         false
       else
-        @pid = Spoon.spawnp 'rackup', *options_array, config_file
+        @pid = Spoon.spawnp 'rackup', *(options_array << (config_file if config_file)).reject(&:nil?)
       end
       wait_for_port
       if running?


### PR DESCRIPTION
Spoon.spawnp cannot accept to ARGV has nil. (spoon (0.0.4))

```
ERROR - Guard::Shotgun failed to achieve its <start>, exception was:
> [#3BFF5287FF7F] TypeError: no implicit conversion of nil into String
> [#3BFF5287FF7F] /home/ma2shita/Development/iotpf/.bundle/gems/ruby/2.1.0/gems/spoon-0.0.4/lib/spoon/unix.rb:175:in `from_string'
...
> [#3BFF5287FF7F] /home/ma2shita/Development/iotpf/.bundle/gems/ruby/2.1.0/gems/guard-shotgun-0.1.1/lib/guard/shotgun.rb:36:in `start'
```
