### PR TITLE
added namespace qualifier to Process

### DIFF
--- a/lib/guard/shotgun.rb
+++ b/lib/guard/shotgun.rb
@@ -49,16 +49,16 @@ module Guard
     # Call with Ctrl-C signal (when Guard quit)
     def stop
       UI.info "Shutting down Rack..."
-      Process.kill("TERM", @pid)
-      Process.wait(@pid)
+      ::Process.kill("TERM", @pid)
+      ::Process.wait(@pid)
       @pid = nil
       true
     end
 
     def stop_without_waiting
       UI.info "Shutting down Rack without waiting..."
-      Process.kill("KILL", @pid)
-      Process.wait(@pid)
+      ::Process.kill("KILL", @pid)
+      ::Process.wait(@pid)
       @pid = nil
       true
     end
@@ -105,7 +105,7 @@ module Guard
     def running?
       begin
         if @pid
-          Process.getpgid @pid
+          ::Process.getpgid @pid
           true
         else
           false


### PR DESCRIPTION
When also using Guard::Process, Guard::Shotgun raised errors such as 
`NoMethodError: undefined method 'getpgid' for Guard::Process:Class` due to a naming conflict.

This changeset ensures that Guard::Shotgun uses the Process class from stdlib.
